### PR TITLE
Added ability to use plugin with arbitrary number of arguments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-markdownit",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-markdownit",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A gulp plug-in for the markdown-it library.",
   "main": "./src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const useMarkdownItPlugin = (md, plugin) => {
   } else if (typeof plugin === 'function') {
     md.use(plugin, md.options)
   } else if (Array.isArray(plugin)) {
-    md.use(plugin[0], plugin[1])
+    md.use(plugin[0], ...plugin.slice(1))
   } else {
     md.use(plugin.plugin, plugin.options)
   }


### PR DESCRIPTION
Without this small change it is not possible to pass an arbitrary number of arguments to plugins.

On the `markdown-it` npm [page](https://www.npmjs.com/package/markdown-it#plugins-load) you can see that this is allowed:
```javascript
var md = require('markdown-it')()
            .use(plugin1)
            .use(plugin2, opts, ...) // <-- arbitrary number of arguments
            .use(plugin3);
```

I would like to use this feature with the [plugin](https://www.npmjs.com/package/markdown-it-for-inline) `markdown-it-inline` which takes an arbitrary number of arguments.

I also modified the version number in package.json for you if you choose to update the npm module.